### PR TITLE
Feature / Add JSON handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ npm install structoform
 #### `jsonConfig={ string }`
 An optional string containing a JSON parsable object. The contents of this object may override the `className`, `layout`, `layoutDirection` or `initValues` prop.
 
-### `className={ string }`
+#### `className={ string }`
 A className string to append to the `<form>` wrapper className.
 
-### `layout={ object }`
+#### `layout={ object }`
 An object containing all the form fields, indexed by a unique key.
 ```js
 const layout = {
@@ -47,13 +47,13 @@ const layout = {
 }
 ```
 
-### `layoutDirection={ string }`
+#### `layoutDirection={ string }`
 Determines how labels should position themselves relative to their respective form element. Specify either `"row"` or `"column"`.
 
-### s`ubmitButton={ node }`
+#### s`ubmitButton={ node }`
 A react element consisting of or containing a `<button>`, to trigger the form `onSubmit` logic.
 
-### `onSubmit={ func }`
+#### `onSubmit={ func }`
 Callback function for submit logic
 
 ## Things todo

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Structoform
 A form builder for React
 
+## Installation
+```sh
+# yarn
+yarn add structoform
+# npm
+npm install structoform
+```
+
 ## Supported form elements
 * Checkbox
 * DateField
@@ -9,14 +17,48 @@ A form builder for React
 * TextArea
 * TextField
 
-
 ## Steps for local developement
 * run `npm link`
-* run `npm run prepublishOnly` to build the package
+* run `npm run prepare` to build the package
 
-### Things todo
+## Api documentation
+
+### `<Form>`
+
+#### `jsonConfig={ string }`
+An optional string containing a JSON parsable object. The contents of this object may override the `className`, `layout`, `layoutDirection` or `initValues` prop.
+
+### `className={ string }`
+A className string to append to the `<form>` wrapper className.
+
+### `layout={ object }`
+An object containing all the form fields, indexed by a unique key.
+```js
+const layout = {
+    name: {
+        // field props
+    },
+    organisation: {
+        // field props
+    },
+    email: {
+        // field props
+    },
+}
+```
+
+### `layoutDirection={ string }`
+Determines how labels should position themselves relative to their respective form element. Specify either `"row"` or `"column"`.
+
+### s`ubmitButton={ node }`
+A react element consisting of or containing a `<button>`, to trigger the form `onSubmit` logic.
+
+### `onSubmit={ func }`
+Callback function for submit logic
+
+## Things todo
 - [ ] Write documentation
-- [ ] Add tests
+- [ ] Add test
 - [ ] Password Field
 - [ ] Phone Field
 - [ ] Autosuggest / Autocomplete

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "css": "node-sass --output-style compressed src/assets/styles/styles.scss -o dist/css",
         "autoprefixer": "postcss -u autoprefixer -r dist/css/*",
         "test": "echo \"Error: no test specified\" && exit 1",
-        "prepare": "babel ./src --out-dir ./dist -s inline && npm run build-css && npm run autoprefixer",
+        "prepare": "babel ./src --out-dir ./dist -s inline && npm run css && npm run autoprefixer",
         "prep": "babel ./src --out-dir ./dist -s inline && npm run css && npm run autoprefixer"
     },
     "repository": {

--- a/src/components/DateField.jsx
+++ b/src/components/DateField.jsx
@@ -16,7 +16,7 @@ const CalendarIcon = () =>
 
 const DateField = ({label, name, placeholder, value, direction, errorMessage, showError, onChange, isVisible}) => {
     const [ id ] = useState(() => uniqueId(`${_.camelCase(label)}-`))
-    const [ currentValue, setCurrentValue ] = useState(moment(value).format('D/MM/YYYY'))
+    const [ currentValue, setCurrentValue ] = useState(value ? moment(value).format('D/MM/YYYY') : '')
 
     const node = useRef();
     const refValue = useRef();

--- a/src/components/DateField.jsx
+++ b/src/components/DateField.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState, useRef } from 'react'
-import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 import { uniqueId, direction } from '../constants/helper'
 import FormItem from './FormItem'

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -4,9 +4,19 @@ import PropTypes from 'prop-types'
 import { TextField, SelectField, DateField, Checkbox, TextArea, RadioButtonGroup, useForm } from "../index"
 import { direction } from '../constants/helper'
 
-const Form = ({ className = '', layout, layoutDirection, initValues = [], submitButton, onSubmit }) => {
+const Form = ({ jsonConfig = '{}', className = '', layout, layoutDirection, initValues = [], submitButton, onSubmit }) => {
 
-    const validationRules = {...layout}
+    const parsedConfig = jsonConfig ? JSON.parse(jsonConfig) : {}
+
+    const config = {
+        className,
+        layout,
+        layoutDirection,
+        initValues,
+        ...parsedConfig,
+    }
+
+    const validationRules = {...config.layout}
 
     Object.keys(validationRules).map((item, i) =>
         validationRules[item] = {type: validationRules[item].type, rules: validationRules[item].validators}
@@ -14,12 +24,12 @@ const Form = ({ className = '', layout, layoutDirection, initValues = [], submit
 
     const { values, errors, handleSubmit, handleChange } = useForm(() => submit(), validationRules)
 
-    const dir = layoutDirection === 'row' ? direction.row : direction.column
+    const dir = config.layoutDirection === 'row' ? direction.row : direction.column
 
     const getValue = (key) => {
         // If no inputes are given, then return default valutes or empty string
         if (!values[key]) {
-            return initValues[key] || ''
+            return config.initValues[key] || ''
         }
         return values[key]
     }
@@ -64,10 +74,10 @@ const Form = ({ className = '', layout, layoutDirection, initValues = [], submit
     }
 
     return (
-        <form className={`form ${className}`} onSubmit={handleSubmit} noValidate >
+        <form className={`form ${config.className}`} onSubmit={handleSubmit} noValidate >
             {
-                Object.keys(layout).map((key, i) => {
-                    return getItem(key, layout[key], i)
+                Object.keys(config.layout).map((key, i) => {
+                    return getItem(key, config.layout[key], i)
                 })
             }
             { submitButton }
@@ -78,8 +88,14 @@ const Form = ({ className = '', layout, layoutDirection, initValues = [], submit
 export default Form
 
 Form.propTypes = {
+    jsonConfig: PropTypes.string,
     className: PropTypes.string,
-    layout: PropTypes.object.isRequired,
+    layout: PropTypes.object,
     layoutDirection: PropTypes.string,
     initValues: PropTypes.array,
+    submitButton: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.node),
+        PropTypes.node
+    ]),
+    onSubmit: PropTypes.func
 }

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import { TextField, SelectField, DateField, Checkbox, TextArea, RadioButtonGroup, useForm, DisplayText } from "../index"
 import { direction } from '../constants/helper'
 
-const Form = ({ jsonConfig = '{}', className = '', layout, layoutDirection, initValues, submitButton, onSubmit }) => {
+const Form = ({ jsonConfig, className = '', layout, layoutDirection, initValues, submitButton, onSubmit }) => {
 
     const parsedConfig = jsonConfig ? JSON.parse(jsonConfig) : {}
 
@@ -93,7 +93,8 @@ const Form = ({ jsonConfig = '{}', className = '', layout, layoutDirection, init
 export default Form
 
 Form.defaultProps = {
-    initValues: {}
+    initValues: {},
+    jsonConfig: '{}',
 }
 
 Form.propTypes = {


### PR DESCRIPTION
Adds the ability to supply Form parameters from a JSON object in a string. E.g.:
```jsx
const config = `{
   "layout": {
      "name": {
        "type": "text",
        "label": "Naam",
        "validators": [
          "isRequired",
      ]
   },
}`

return (
   <Form jsonConfig={config} />
)
```
This config json may contain the `className`, `layout`, `layoutDirection` or `initValues` props, and will override them if they already exist, e.g.:
```jsx
return (
   <Form jsonConfig={`{"layoutDirection": "row"}"`} layoutDirection="column" />
   {<!-- Direction will be "row" -->}
)
```
The README docs have been updated to reflect this change.