### PR TITLE
Feature / Add displaytext

### DIFF
--- a/src/components/DisplayText.jsx
+++ b/src/components/DisplayText.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react'
+import PropTypes from "prop-types"
+import { uniqueId, direction } from '../constants/helper'
+import FormItem from './FormItem'
+import _ from 'lodash'
+
+const TextField = ({label, value, wrapper, direction }) => {
+    const [ id ] = useState(() => uniqueId(`${_.camelCase(label)}-`))
+
+    return (
+        <FormItem label={label} id={id} direction={direction}>
+            {React.createElement(wrapper, {}, value)}
+        </FormItem>
+    )
+}
+
+export default TextField
+
+TextField.wrapperTypes = {
+    DIV: 'div',
+    P: 'p',
+    H1: 'h1',
+    H2: 'h2',
+    H3: 'h3',
+    H4: 'h4',
+}
+
+TextField.defaultProps = {
+    wrapper: TextField.wrapperTypes.P
+}
+
+TextField.propTypes = {
+    label: PropTypes.string,
+    value: PropTypes.string,
+    wrapper: PropTypes.oneOf(Object.values(TextField.wrapperTypes)),
+    direction: PropTypes.oneOf(Object.values(direction)),
+}

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import { TextField, SelectField, DateField, Checkbox, TextArea, RadioButtonGroup, useForm } from "../index"
+import { TextField, SelectField, DateField, Checkbox, TextArea, RadioButtonGroup, useForm, DisplayText } from "../index"
 import { direction } from '../constants/helper'
 
 const Form = ({ className = '', layout, layoutDirection, initValues = [], submitButton, onSubmit }) => {
@@ -36,28 +36,30 @@ const Form = ({ className = '', layout, layoutDirection, initValues = [], submit
             case 'phone':
             case 'number':
                 return <TextField key={index} type={value.type} name={key} label={value.label} direction={dir}
-                                  placeholder={value.placeholder || ''} value={values[key]} onChange={handleChange}
-                                  showError={!_.isEmpty(errors[key])} errorMessage={_.head(errors[key]) || ''}/>
+                                placeholder={value.placeholder || ''} value={values[key]} onChange={handleChange}
+                                showError={!_.isEmpty(errors[key])} errorMessage={_.head(errors[key]) || ''}/>
             case 'select':
                 return <SelectField key={key} label={value.label} values={value.values || []} direction={dir}
-                                    name={key} placeholder={value.placeholder || ''} onChange={handleChange}
-                                    showError={!_.isEmpty(errors[key])} errorMessage={_.head(errors[key]) || ''}/>
+                                name={key} placeholder={value.placeholder || ''} onChange={handleChange}
+                                showError={!_.isEmpty(errors[key])} errorMessage={_.head(errors[key]) || ''}/>
             case 'checkbox':
                 return <Checkbox key={key} label={value.label} name={key} value={getValue(key) || false}
-                                 onChange={handleChange} showError={!_.isEmpty(errors[key])}
-                                 errorMessage={_.head(errors[key]) || ''}/>
+                                onChange={handleChange} showError={!_.isEmpty(errors[key])}
+                                errorMessage={_.head(errors[key]) || ''}/>
             case 'textarea':
                 return <TextArea key={key} label={value.label} name={key} direction={dir} onChange={handleChange}
-                                 showError={!_.isEmpty(errors[key])} placeholder={value.placeholder}
-                                 errorMessage={_.head(errors[key]) || ''} value={values[key]}/>
+                                showError={!_.isEmpty(errors[key])} placeholder={value.placeholder}
+                                errorMessage={_.head(errors[key]) || ''} value={values[key]}/>
             case 'date':
                 return <DateField key={index} name={key} label={value.label} direction={dir} onChange={handleChange}
-                                  placeholder={value.placeholder || ''} value={values[key]}
-                                  showError={!_.isEmpty(errors[key])} errorMessage={_.head(errors[key]) || ''}/>
+                                placeholder={value.placeholder || ''} value={values[key]}
+                                showError={!_.isEmpty(errors[key])} errorMessage={_.head(errors[key]) || ''}/>
             case 'radio':
                 return <RadioButtonGroup key={index} label={value.label} inline={value.inline} items={value.values}
-                                         name={key} showError={!_.isEmpty(errors[key])} onChange={handleChange}
-                                         errorMessage={_.head(errors[key]) || ''}/>
+                                name={key} showError={!_.isEmpty(errors[key])} onChange={handleChange}
+                                errorMessage={_.head(errors[key]) || ''}/>
+            case 'displaytext':
+                return <DisplayText key={index} label={value.label} direction={dir} value={value.content} wrapper={value.wrapper} />
             default:
                 throw new Error(`Unhandled form type: ${value.type}`)
         }

--- a/src/components/FormItem.jsx
+++ b/src/components/FormItem.jsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import _ from 'lodash'
 import {direction} from "../constants/helper";
 
 const FormItem = ({label, id, direction, children}) =>
     <div className={`form-item form-item${direction}`}>
-        {label !== '' && <label className={`form-item__label`} htmlFor={id}>{label}</label>}
+        {!_.isNil(label) && <label className={`form-item__label`} htmlFor={id}>{label}</label>}
         <div className="form-item__inner">
             {children}
         </div>
@@ -13,7 +14,7 @@ const FormItem = ({label, id, direction, children}) =>
 export default FormItem
 
 FormItem.propTypes = {
-    label: PropTypes.string.isRequired,
+    label: PropTypes.string,
     id: PropTypes.string.isRequired,
     direction: PropTypes.oneOf(Object.values(direction)),
     children: PropTypes.array,

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import DateField from './components/DateField'
 import TextArea from './components/TextArea'
 import PasswordField from './components/PasswordField'
 import Checkbox from './components/Checkbox'
+import DisplayText from './components/DisplayText'
 import Form from './components/Form'
 import useForm from './hooks/useForm'
 import RadioButtonGroup from './components/RadioButtonGroup'
@@ -15,6 +16,7 @@ export {
     PasswordField,
     Checkbox,
     TextArea,
+    DisplayText,
     Form,
     useForm,
     RadioButtonGroup


### PR DESCRIPTION
Added the `<DisplayText>` form item type. A really simple form item that does not return a value, and instead just displays a string of text within the form. Can be styled however the user wishes.

### Example:

```js
const layout = {
    message1: {
        type: 'displaytext',
        label: 'My message',
        content: 'Foo',
        wrapper: 'h1'
    },
    message2: {
        type: 'displaytext',
        label: 'My less important message',
        content: 'Bar',
        wrapper: 'h3'
    },
    message3: {
        type: 'displaytext',
        content: 'No label, so a really large message is possible. Could be used as a divider',
        wrapper: 'p'
    },
    message4: {
        type: 'displaytext',
        content: 'Label is specified, but is left empty',
        label: '',
        wrapper: 'p'
    },
    message5: {
        type: 'displaytext',
        label: 'React elements as content',
        content: <ul style={{marginLeft: '1em'}}><li>My</li><li>Shopping</li><li>List</li></ul>,
        wrapper: 'div'
    },
}
```

Results into:

![Screenshot 2020-02-11 at 12 57 38](https://user-images.githubusercontent.com/17108331/74234871-2373ff80-4cce-11ea-9a7e-fd3407f44bfe.png)
