### PR TITLE
Feature / Add conditionals

### DIFF
--- a/src/components/Checkbox.jsx
+++ b/src/components/Checkbox.jsx
@@ -25,6 +25,10 @@ const Checkbox = ({label, name, value, showError, onChange, isVisible}) => {
 
 export default Checkbox
 
+Checkbox.defaultProps = {
+    isVisible: true,
+}
+
 Checkbox.propTypes = {
     label: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,

--- a/src/components/Checkbox.jsx
+++ b/src/components/Checkbox.jsx
@@ -3,17 +3,17 @@ import PropTypes from 'prop-types'
 import { uniqueId } from '../constants/helper'
 import _ from "lodash";
 
-const Checkbox = ({label, name, value, showError, onChange}) => {
+const Checkbox = ({label, name, value, showError, onChange, isVisible}) => {
     const [ id ] = useState(() => uniqueId(`${_.camelCase(label)}-`))
     const [ isChecked, setIsChecked ] = useState(false)
 
     const handleChange = e => setIsChecked(e.target.checked)
 
     useEffect(() => {
-        onChange(name, isChecked)
-    }, [isChecked])
+        onChange(name, isChecked, { isVisible })
+    }, [isChecked, isVisible])
 
-    return (
+    return isVisible && (
         <div className={`form-item`}>
             <input className={`form-item__checkbox`} type='checkbox' name={name} onChange={handleChange}
                    checked={isChecked} id={id}/>
@@ -30,5 +30,6 @@ Checkbox.propTypes = {
     name: PropTypes.string.isRequired,
     value: PropTypes.bool,
     showError: PropTypes.bool,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    isVisible: PropTypes.bool.isRequired
 }

--- a/src/components/DateField.jsx
+++ b/src/components/DateField.jsx
@@ -14,7 +14,7 @@ const CalendarIcon = () =>
         </g>
     </svg>
 
-const DateField = ({label, name, placeholder, value, direction, errorMessage, showError, onChange}) => {
+const DateField = ({label, name, placeholder, value, direction, errorMessage, showError, onChange, isVisible}) => {
     const [ id ] = useState(() => uniqueId(`${_.camelCase(label)}-`))
     const [ currentValue, setCurrentValue ] = useState('')
 
@@ -26,7 +26,7 @@ const DateField = ({label, name, placeholder, value, direction, errorMessage, sh
         if (refValue.current !== currentValue) {
             refValue.current = currentValue
 
-            onChange(name, currentValue)
+            onChange(name, currentValue, { isVisible })
 
             setIsCalendarPresent(false)
         }
@@ -39,7 +39,7 @@ const DateField = ({label, name, placeholder, value, direction, errorMessage, sh
 
         return () => document.removeEventListener('mousedown', handleClickOutside)
 
-    }, [isCalendarPresent, currentValue])
+    }, [isCalendarPresent, currentValue, isVisible])
 
     const handleClickOutside = e => {
         if (node.current.contains(e.target)) {
@@ -56,7 +56,7 @@ const DateField = ({label, name, placeholder, value, direction, errorMessage, sh
 
     const handleChange = e => setCurrentValue(e.target.value)
 
-    return (
+    return isVisible && (
         <FormItem label={label} id={id} direction={direction}>
             <div className="form-item__input-wrapper">
                 <input className={`form-item__input ${showError && 'error'}`} placeholder={placeholder}
@@ -84,5 +84,6 @@ DateField.propTypes = {
     direction: PropTypes.oneOf(Object.values(direction)),
     errorMessage: PropTypes.string,
     showError: PropTypes.bool.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    isVisible: PropTypes.bool.isRequired
 }

--- a/src/components/DateField.jsx
+++ b/src/components/DateField.jsx
@@ -76,6 +76,11 @@ const DateField = ({label, name, placeholder, value, direction, errorMessage, sh
 
 export default DateField
 
+DateField.defaultProps = {
+    value: '',
+    isVisible: true,
+}
+
 DateField.propTypes = {
     label: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
 import { TextField, SelectField, DateField, Checkbox, TextArea, RadioButtonGroup, useForm } from "../index"
-import { direction } from '../constants/helper'
+import { direction, comparators } from '../constants/helper'
 
 const Form = ({ className = '', layout, layoutDirection, initValues = [], submitButton, onSubmit }) => {
 
@@ -15,6 +15,32 @@ const Form = ({ className = '', layout, layoutDirection, initValues = [], submit
     const { values, errors, handleSubmit, handleChange } = useForm(() => submit(), validationRules)
 
     const dir = layoutDirection === 'row' ? direction.row : direction.column
+
+    const checkConditionals = (key) => {
+        const conditionals = _.get(layout, [key, 'conditionals'], [])
+
+        return conditionals.every(conditional => {
+            const field =  _.get(conditional, 'field')
+            const value = _.get(conditional, 'value')
+
+            if (!field || !value) {
+                return false
+            }
+
+            switch(_.get(conditional, 'condition', 'equals')) {
+                case comparators.IS:
+                    return getValue(field) === value
+                case comparators.ISNOT:
+                    return getValue(field) !== value
+                case comparators.MORE:
+                    return Number(getValue(field)) > Number(value)
+                case comparators.LESS:
+                    return Number(getValue(field) < Number(value))
+                default:
+                    return true
+            }
+        })
+    }
 
     const getValue = (key) => {
         // If no inputes are given, then return default valutes or empty string
@@ -67,7 +93,7 @@ const Form = ({ className = '', layout, layoutDirection, initValues = [], submit
         <form className={`form ${className}`} onSubmit={handleSubmit} noValidate >
             {
                 Object.keys(layout).map((key, i) => {
-                    return getItem(key, layout[key], i)
+                    return checkConditionals(key) && getItem(key, layout[key], i)
                 })
             }
             { submitButton }

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -28,7 +28,7 @@ const Form = ({ className = '', layout, layoutDirection, initValues = [], submit
         onSubmit(Object.values(errors).every(x => x === null) ? null : errors, values)
     }
 
-    const getItem = (key, value, index) => {
+    const getItem = (key, value, index, isVisible) => {
         switch(value.type) {
             case 'text':
             case 'password':
@@ -37,27 +37,32 @@ const Form = ({ className = '', layout, layoutDirection, initValues = [], submit
             case 'number':
                 return <TextField key={index} type={value.type} name={key} label={value.label} direction={dir}
                                   placeholder={value.placeholder || ''} value={values[key]} onChange={handleChange}
-                                  showError={!_.isEmpty(errors[key])} errorMessage={_.head(errors[key]) || ''}/>
+                                  showError={!_.isEmpty(errors[key])} errorMessage={_.head(errors[key]) || ''}
+                                  isVisible={isVisible} />
             case 'select':
                 return <SelectField key={key} label={value.label} values={value.values || []} direction={dir}
                                     name={key} placeholder={value.placeholder || ''} onChange={handleChange}
-                                    showError={!_.isEmpty(errors[key])} errorMessage={_.head(errors[key]) || ''}/>
+                                    showError={!_.isEmpty(errors[key])} errorMessage={_.head(errors[key]) || ''}
+                                    isVisible={isVisible} />
             case 'checkbox':
                 return <Checkbox key={key} label={value.label} name={key} value={getValue(key) || false}
                                  onChange={handleChange} showError={!_.isEmpty(errors[key])}
-                                 errorMessage={_.head(errors[key]) || ''}/>
+                                 errorMessage={_.head(errors[key]) || ''}
+                                 isVisible={isVisible} />
             case 'textarea':
                 return <TextArea key={key} label={value.label} name={key} direction={dir} onChange={handleChange}
                                  showError={!_.isEmpty(errors[key])} placeholder={value.placeholder}
-                                 errorMessage={_.head(errors[key]) || ''} value={values[key]}/>
+                                 errorMessage={_.head(errors[key]) || ''} value={values[key]}
+                                 isVisible={isVisible} />
             case 'date':
                 return <DateField key={index} name={key} label={value.label} direction={dir} onChange={handleChange}
                                   placeholder={value.placeholder || ''} value={values[key]}
-                                  showError={!_.isEmpty(errors[key])} errorMessage={_.head(errors[key]) || ''}/>
+                                  showError={!_.isEmpty(errors[key])} errorMessage={_.head(errors[key]) || ''}
+                                  isVisible={isVisible} />
             case 'radio':
                 return <RadioButtonGroup key={index} label={value.label} inline={value.inline} items={value.values}
                                          name={key} showError={!_.isEmpty(errors[key])} onChange={handleChange}
-                                         errorMessage={_.head(errors[key]) || ''}/>
+                                         errorMessage={_.head(errors[key]) || ''} isVisible={isVisible} />
             default:
                 throw new Error(`Unhandled form type: ${value.type}`)
         }
@@ -67,7 +72,7 @@ const Form = ({ className = '', layout, layoutDirection, initValues = [], submit
         <form className={`form ${className}`} onSubmit={handleSubmit} noValidate >
             {
                 Object.keys(layout).map((key, i) => {
-                    return checkConditionals(_.get(layout, key, {})) && getItem(key, layout[key], i)
+                    return getItem(key, layout[key], i, checkConditionals(_.get(layout, key, {})))
                 })
             }
             { submitButton }

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import _ from 'lodash'
 import PropTypes from 'prop-types'
 import { TextField, SelectField, DateField, Checkbox, TextArea, RadioButtonGroup, useForm } from "../index"
-import { direction, comparators } from '../constants/helper'
+import { direction } from '../constants/helper'
 
 const Form = ({ className = '', layout, layoutDirection, initValues = [], submitButton, onSubmit }) => {
 
@@ -12,35 +12,9 @@ const Form = ({ className = '', layout, layoutDirection, initValues = [], submit
         validationRules[item] = {type: validationRules[item].type, rules: validationRules[item].validators}
     )
 
-    const { values, errors, handleSubmit, handleChange } = useForm(() => submit(), validationRules)
+    const { values, errors, handleSubmit, handleChange, checkConditionals } = useForm(() => submit(), validationRules)
 
     const dir = layoutDirection === 'row' ? direction.row : direction.column
-
-    const checkConditionals = (key) => {
-        const conditionals = _.get(layout, [key, 'conditionals'], [])
-
-        return conditionals.every(conditional => {
-            const field =  _.get(conditional, 'field')
-            const value = _.get(conditional, 'value')
-
-            if (!field || !value) {
-                return false
-            }
-
-            switch(_.get(conditional, 'condition', 'equals')) {
-                case comparators.IS:
-                    return getValue(field) === value
-                case comparators.ISNOT:
-                    return getValue(field) !== value
-                case comparators.MORE:
-                    return Number(getValue(field)) > Number(value)
-                case comparators.LESS:
-                    return Number(getValue(field) < Number(value))
-                default:
-                    return true
-            }
-        })
-    }
 
     const getValue = (key) => {
         // If no inputes are given, then return default valutes or empty string
@@ -93,7 +67,7 @@ const Form = ({ className = '', layout, layoutDirection, initValues = [], submit
         <form className={`form ${className}`} onSubmit={handleSubmit} noValidate >
             {
                 Object.keys(layout).map((key, i) => {
-                    return checkConditionals(key) && getItem(key, layout[key], i)
+                    return checkConditionals(_.get(layout, key, {})) && getItem(key, layout[key], i)
                 })
             }
             { submitButton }

--- a/src/components/RadioButtonGroup.jsx
+++ b/src/components/RadioButtonGroup.jsx
@@ -34,6 +34,10 @@ const RadioButtonGroup = ({items, name, label, inline, errorMessage, showError, 
 
 export default RadioButtonGroup
 
+RadioButtonGroup.defaultProps = {
+    isVisible: true,
+}
+
 RadioButtonGroup.propTypes = {
     items: PropTypes.arrayOf(PropTypes.shape).isRequired,
     name: PropTypes.string.isRequired,

--- a/src/components/RadioButtonGroup.jsx
+++ b/src/components/RadioButtonGroup.jsx
@@ -4,20 +4,20 @@ import {direction, uniqueId} from '../constants/helper'
 import RadioButton from './RadioButton'
 import _ from "lodash";
 
-const RadioButtonGroup = ({items, name, label, inline, errorMessage, showError, onChange}) => {
+const RadioButtonGroup = ({items, name, label, inline, errorMessage, showError, onChange, isVisible}) => {
     const [ id ] = useState(() => uniqueId(`${_.camelCase(label)}-`))
     const [ currentValue, setCurrentValue] = useState('')
 
     useEffect(() => {
-        onChange(name, currentValue)
-    }, [currentValue])
+        onChange(name, currentValue, { isVisible })
+    }, [currentValue, isVisible])
 
     const handleChange = (e) => {
         e.preventDefault()
         setCurrentValue(e.target.value)
     }
 
-    return (
+    return isVisible && (
         <div className={`form-item`}>
             {label !== '' && <label className={`form-item__label`} htmlFor={id}>{label}</label>}
             <div className={`form-item__radiogroup${inline ? direction.row : direction.column}`}>
@@ -41,5 +41,6 @@ RadioButtonGroup.propTypes = {
     inline: PropTypes.bool.isRequired,
     errorMessage: PropTypes.string,
     showError: PropTypes.bool.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    isVisible: PropTypes.bool.isRequired
 }

--- a/src/components/SelectField.jsx
+++ b/src/components/SelectField.jsx
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types'
 import { uniqueId, direction } from '../constants/helper'
 import FormItem from './FormItem'
 
-const SelectField = ({label, name, placeholder, values, direction, disabled = false, errorMessage, showError, onChange}) => {
+const SelectField = ({label, name, placeholder, values, direction, disabled = false, errorMessage, showError, onChange, isVisible}) => {
     const [ id ] = useState(() => uniqueId(`${_.camelCase(label)}-`))
     const [ currentValue, setCurrentValue ] = useState(placeholder)
     const [ isChecked, setIsChecked ] = useState(false)
 
     useEffect(() => {
-        onChange(name, isChecked ? currentValue : null)
-    }, [currentValue])
+        onChange(name, isChecked ? currentValue : null, { isVisible })
+    }, [currentValue, isVisible])
 
     const placeholderStyling = () => `${currentValue === placeholder && 'form-item__select--placeholder'}`
 
@@ -19,7 +19,7 @@ const SelectField = ({label, name, placeholder, values, direction, disabled = fa
         setCurrentValue(e.target.value)
     })
 
-    return (
+    return isVisible && (
         <FormItem label={label} id={id} direction={direction}>
             <select className={`form-item__select ${placeholderStyling()} ${showError ? 'error' : ''}`}
                     htmlFor={id} name={name} onChange={handleChange} value={currentValue} 
@@ -47,5 +47,6 @@ SelectField.propTypes = {
     disabled: PropTypes.bool,
     errorMessage: PropTypes.string,
     showError: PropTypes.bool.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    isVisible: PropTypes.bool.isRequired
 }

--- a/src/components/SelectField.jsx
+++ b/src/components/SelectField.jsx
@@ -38,6 +38,10 @@ const SelectField = ({label, name, placeholder, values, direction, disabled = fa
 
 export default SelectField
 
+SelectField.defaultProps = {
+    isVisible: true,
+}
+
 SelectField.propTypes = {
     label: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,

--- a/src/components/TextArea.jsx
+++ b/src/components/TextArea.jsx
@@ -31,6 +31,10 @@ const TextArea = ({label, name, value = '', direction, placeholder, onChange, er
 
 export default TextArea
 
+TextArea.defaultProps = {
+    isVisible: true,
+}
+
 TextArea.propTypes = {
     label: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,

--- a/src/components/TextArea.jsx
+++ b/src/components/TextArea.jsx
@@ -3,17 +3,17 @@ import PropTypes from 'prop-types'
 import { direction, uniqueId } from '../constants/helper'
 import _ from 'lodash'
 
-const TextArea = ({label, name, value = '', direction, placeholder, onChange, errorMessage, showError}) => {
+const TextArea = ({label, name, value = '', direction, placeholder, onChange, errorMessage, showError, isVisible}) => {
     const [ id ] = useState(() => uniqueId(`${_.camelCase(label)}-`))
     const [ currentValue, setCurrentValue ] = useState('')
 
     useEffect(() => {
-        onChange(name, currentValue)
-    }, [currentValue])
+        onChange(name, currentValue, { isVisible })
+    }, [currentValue, isVisible])
 
     const handleChange = e => setCurrentValue(e.target.value)
 
-     return (
+     return isVisible && (
          <div className={`form-item form-item${direction}`}>
 
              {label !== '' && <label className={`form-item__label`} htmlFor={id}>{label}</label>}
@@ -39,5 +39,6 @@ TextArea.propTypes = {
     placeholder: PropTypes.string,
     errorMessage: PropTypes.string,
     showError: PropTypes.bool.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    isVisible: PropTypes.bool.isRequired
 }

--- a/src/components/TextField.jsx
+++ b/src/components/TextField.jsx
@@ -6,7 +6,7 @@ import _ from 'lodash'
 
 const TextField = ({label, name, placeholder, value, direction, type, errorMessage, showError, onChange}) => {
     const [ id ] = useState(() => uniqueId(`${_.camelCase(label)}-`))
-    const [currentValue, setCurrentValue] = useState('')
+    const [currentValue, setCurrentValue] = useState(value)
 
     useEffect(() => {
         onChange(name, currentValue)
@@ -17,13 +17,17 @@ const TextField = ({label, name, placeholder, value, direction, type, errorMessa
     return (
         <FormItem label={label} id={id} direction={direction}>
             <input className={`form-item__input ${showError ? 'error' : ''}`} placeholder={placeholder} type={type}
-                   onChange={handleChange} name={name} htmlFor={id} value={currentValue} defaultValue={value}/>
+                   onChange={handleChange} name={name} htmlFor={id} value={currentValue}/>
             <span className={`error-label ${showError ? '' : 'hide'}`}>{errorMessage}</span>
         </FormItem>
     )
 }
 
 export default TextField
+
+TextField.defaultProps = {
+    value: ''
+}
 
 TextField.propTypes = {
     label: PropTypes.string.isRequired,

--- a/src/components/TextField.jsx
+++ b/src/components/TextField.jsx
@@ -4,17 +4,17 @@ import { uniqueId, direction } from '../constants/helper'
 import FormItem from './FormItem'
 import _ from 'lodash'
 
-const TextField = ({label, name, placeholder, value, direction, type, errorMessage, showError, onChange}) => {
+const TextField = ({label, name, placeholder, value, direction, type, errorMessage, showError, onChange, isVisible}) => {
     const [ id ] = useState(() => uniqueId(`${_.camelCase(label)}-`))
     const [currentValue, setCurrentValue] = useState(value)
 
     useEffect(() => {
-        onChange(name, currentValue)
-    }, [currentValue])
+        onChange(name, currentValue, { isVisible })
+    }, [currentValue, isVisible])
 
     const handleChange = e => setCurrentValue(e.target.value)
 
-    return (
+    return isVisible && (
         <FormItem label={label} id={id} direction={direction}>
             <input className={`form-item__input ${showError ? 'error' : ''}`} placeholder={placeholder} type={type}
                    onChange={handleChange} name={name} htmlFor={id} value={currentValue}/>
@@ -38,5 +38,6 @@ TextField.propTypes = {
     type: PropTypes.string.isRequired,
     errorMessage: PropTypes.string,
     showError: PropTypes.bool.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    isVisible: PropTypes.bool.isRequired
 }

--- a/src/components/TextField.jsx
+++ b/src/components/TextField.jsx
@@ -26,7 +26,8 @@ const TextField = ({label, name, placeholder, value, direction, type, errorMessa
 export default TextField
 
 TextField.defaultProps = {
-    value: ''
+    value: '',
+    isVisible: true,
 }
 
 TextField.propTypes = {

--- a/src/constants/helper.js
+++ b/src/constants/helper.js
@@ -34,6 +34,7 @@ const copy = {
 }
 
 const comparators = {
+    TRUTHY: 'truthy',
     IS: 'is',
     ISNOT: 'isnot',
     MORE: 'morethan',

--- a/src/constants/helper.js
+++ b/src/constants/helper.js
@@ -33,9 +33,17 @@ const copy = {
     }
 }
 
+const comparators = {
+    IS: 'is',
+    ISNOT: 'isnot',
+    MORE: 'morethan',
+    LESS: 'lessthan'
+}
+
 export {
     id,
     uniqueId,
     copy,
-    direction
+    direction,
+    comparators
 }

--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -53,14 +53,16 @@ const useForm = (callback, validators) => {
         const conditionals = _.get(item, 'conditionals', [])
 
         return conditionals.every(conditional => {
-            const field =  _.get(conditional, 'field')
-            const value = _.get(conditional, 'value')
-
-            if (!field || _.isNil(value)) {
-                return false
+            if (typeof conditional === "boolean") {
+                return conditional
             }
 
-            switch(_.get(conditional, 'condition', 'equals')) {
+            const rule = _.isPlainObject(conditional) ? conditional : { field: conditional, condition: comparators.TRUTHY }
+
+            const field =  _.get(rule, 'field', '')
+            const value = _.get(rule, 'value')
+
+            switch(_.get(rule, 'condition', comparators.IS)) {
                 case comparators.IS:
                     return values[field] === value
                 case comparators.ISNOT:
@@ -69,8 +71,9 @@ const useForm = (callback, validators) => {
                     return Number(values[field]) > Number(value)
                 case comparators.LESS:
                     return Number(values[field] < Number(value))
+                case comparators.TRUTHY:
                 default:
-                    return true
+                    return !!values[field]
             }
         })
     }

--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -56,7 +56,7 @@ const useForm = (callback, validators) => {
             const field =  _.get(conditional, 'field')
             const value = _.get(conditional, 'value')
 
-            if (!field || !value) {
+            if (!field || _.isNil(value)) {
                 return false
             }
 

--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -4,6 +4,7 @@ import { copy, comparators } from '../constants/helper';
 const useForm = (callback, validators) => {
     const [values, setValues] = useState({})
     const [errors, setErrors] = useState({})
+    const [statuses, setStatuses] = useState({})
     const [isSubmitting, setIsSubmitting] = useState(false)
 
     useEffect(() => {
@@ -25,7 +26,7 @@ const useForm = (callback, validators) => {
 
         Object.keys(validators).forEach( validator => {
             Object.keys(values).forEach((key) => {
-                if ( key === validator ) {
+                if ( key === validator && _.get(statuses, [key, 'isVisible'], true) ) {
                     setErrors(errors => ( { ...errors, [key]: validate(values[key], validators[validator])} ))
                 }
             })
@@ -34,15 +35,21 @@ const useForm = (callback, validators) => {
         setIsSubmitting(true)
     }
 
-    const handleChange = (key, value) => {
+    const handleChange = (key, value, status) => {
         // Remove current error on typing
         setErrors(errors => ({ ...errors, [key]: null}))
 
         // Store values of input elements
         setValues(values => ({ ...values, [key]: value}))
+
+        // Store statuses of input elements
+        setStatuses(statuses => ({ ...statuses, [key]: status}))
     }
 
     const checkConditionals = (item) => {
+        /**
+         * Returns true if all the conditions are met
+         */
         const conditionals = _.get(item, 'conditionals', [])
 
         return conditionals.every(conditional => {

--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -1,5 +1,5 @@
 import {useState, useEffect} from 'react'
-import { copy } from '../constants/helper';
+import { copy, comparators } from '../constants/helper';
 
 const useForm = (callback, validators) => {
     const [values, setValues] = useState({})
@@ -42,11 +42,38 @@ const useForm = (callback, validators) => {
         setValues(values => ({ ...values, [key]: value}))
     }
 
+    const checkConditionals = (item) => {
+        const conditionals = _.get(item, 'conditionals', [])
+
+        return conditionals.every(conditional => {
+            const field =  _.get(conditional, 'field')
+            const value = _.get(conditional, 'value')
+
+            if (!field || !value) {
+                return false
+            }
+
+            switch(_.get(conditional, 'condition', 'equals')) {
+                case comparators.IS:
+                    return values[field] === value
+                case comparators.ISNOT:
+                    return values[field] !== value
+                case comparators.MORE:
+                    return Number(values[field]) > Number(value)
+                case comparators.LESS:
+                    return Number(values[field] < Number(value))
+                default:
+                    return true
+            }
+        })
+    }
+
     return {
         values,
         errors,
         handleSubmit,
-        handleChange
+        handleChange,
+        checkConditionals
     }
 }
 


### PR DESCRIPTION
Adds support for conditional fields. If a condition (or multiple conditions) pass, show the field, otherwise show nothing.

### Example:

```js
const layout = {
    organisation: {
        type: 'text',
        label: 'Organisatie of gemeente',
        validators: [
            'isRequired',
        ],
        conditionals: [
            {
                field: 'name',
                condition: 'is',
                value: 'foo'
            },
            {
                field: 'email',
                condition: 'isnot',
                value: 'bar'
            }
        ]
    },
}
```

The above code will result in a field that is visible if "name" is set to "foo", but "email" is not set to "bar".

You may also only supply the field name. The application will compare the field value with 'truthy';

```js
const conditionals = [
   'email'
]
```

The above code will result in a field that is only visible if 'email' has a value

You may also define an external variable. The application will convert it to a boolean;

```js
const showEmailField = false;

const conditionals = [
   showEmailField
]
```

The above code will result in a field that is only visible if `showEmailField` is set to `true`.