### PR TITLE
Feature/ Update RadioButtonGroup

### DIFF
--- a/src/assets/styles/styles.scss
+++ b/src/assets/styles/styles.scss
@@ -185,7 +185,6 @@ $graphite: #4A4A4A;
     }
 
     & + label {
-      display: inline-block;
       height: 20px;
       position: relative;
       padding: 0 30px;

--- a/src/assets/styles/styles.scss
+++ b/src/assets/styles/styles.scss
@@ -165,12 +165,37 @@ $graphite: #4A4A4A;
   /*
   RADIO BUTTON
    */
+  .radio-wrapper {
+    flex: 1;
+  }
+  
   &__radio {
+    &--tabs {
+      & + label {
+        width: 100%;
+        text-align: center;
+        padding: 0;
+        height: initial !important;
+        line-height: 3em;
+        border-bottom: 1px solid $grey;
+        color: $grey;
+        display: block;
+      }
 
-    &__wrapper {
-      display: flex;
-      flex-direction: column;
+      &:checked + label {
+        border-bottom: 1px solid $night;
+        color: $night;
+      }
+
+      & + label:before {
+        display: none
+      }
+
+      & + label:after {
+        display: none
+      }
     }
+    
     &[type='radio'] {
       display: none;
     }

--- a/src/assets/styles/styles.scss
+++ b/src/assets/styles/styles.scss
@@ -172,9 +172,7 @@ $graphite: #4A4A4A;
   &__radio {
     &--tabs {
       & + label {
-        width: 100%;
         text-align: center;
-        padding: 0;
         height: initial !important;
         line-height: 3em;
         border-bottom: 1px solid $grey;

--- a/src/components/DateField.jsx
+++ b/src/components/DateField.jsx
@@ -16,7 +16,7 @@ const CalendarIcon = () =>
 
 const DateField = ({label, name, placeholder, value, direction, errorMessage, showError, onChange}) => {
     const [ id ] = useState(() => uniqueId(`${_.camelCase(label)}-`))
-    const [ currentValue, setCurrentValue ] = useState('')
+    const [ currentValue, setCurrentValue ] = useState(value)
 
     const node = useRef();
     const refValue = useRef();
@@ -61,7 +61,7 @@ const DateField = ({label, name, placeholder, value, direction, errorMessage, sh
             <div className="form-item__input-wrapper">
                 <input className={`form-item__input ${showError && 'error'}`} placeholder={placeholder}
                        onClick={handleInputClick} name={name} htmlFor={id} onChange={handleChange}
-                       value={currentValue} defaultValue={value}/>
+                       value={currentValue}/>
                 <CalendarIcon/>
             </div>
             <span className={`error-label ${showError ? '' : 'hide'}`}>{errorMessage}</span>
@@ -75,6 +75,10 @@ const DateField = ({label, name, placeholder, value, direction, errorMessage, sh
 }
 
 export default DateField
+
+DateField.defaultProps = {
+    value: '',
+}
 
 DateField.propTypes = {
     label: PropTypes.string.isRequired,

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -55,9 +55,10 @@ const Form = ({ className = '', layout, layoutDirection, initValues, submitButto
                                   placeholder={value.placeholder || ''} value={values[key]}
                                   showError={!_.isEmpty(errors[key])} errorMessage={_.head(errors[key]) || ''}/>
             case 'radio':
-                return <RadioButtonGroup key={index} label={value.label} direction={dir} inline={value.inline} items={value.values}
-                                         name={key} showError={!_.isEmpty(errors[key])} onChange={handleChange}
-                                         errorMessage={_.head(errors[key]) || ''} renderTabs={value.renderTabs}/>
+                return <RadioButtonGroup key={index} label={value.label} value={getValue(key)} direction={dir} 
+                                        inline={value.inline} items={value.values}
+                                        name={key} showError={!_.isEmpty(errors[key])} onChange={handleChange}
+                                        errorMessage={_.head(errors[key]) || ''} renderTabs={value.renderTabs}/>
             default:
                 throw new Error(`Unhandled form type: ${value.type}`)
         }

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -55,7 +55,7 @@ const Form = ({ className = '', layout, layoutDirection, initValues = [], submit
                                   placeholder={value.placeholder || ''} value={values[key]}
                                   showError={!_.isEmpty(errors[key])} errorMessage={_.head(errors[key]) || ''}/>
             case 'radio':
-                return <RadioButtonGroup key={index} label={value.label} inline={value.inline} items={value.values}
+                return <RadioButtonGroup key={index} label={value.label} direction={dir} inline={value.inline} items={value.values}
                                          name={key} showError={!_.isEmpty(errors[key])} onChange={handleChange}
                                          errorMessage={_.head(errors[key]) || ''}/>
             default:

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import { TextField, SelectField, DateField, Checkbox, TextArea, RadioButtonGroup, useForm } from "../index"
 import { direction } from '../constants/helper'
 
-const Form = ({ className = '', layout, layoutDirection, initValues = [], submitButton, onSubmit }) => {
+const Form = ({ className = '', layout, layoutDirection, initValues, submitButton, onSubmit }) => {
 
     const validationRules = {...layout}
 
@@ -19,7 +19,7 @@ const Form = ({ className = '', layout, layoutDirection, initValues = [], submit
     const getValue = (key) => {
         // If no inputes are given, then return default valutes or empty string
         if (!values[key]) {
-            return initValues[key] || ''
+            return _.get(initValues, key, '')
         }
         return values[key]
     }
@@ -39,7 +39,7 @@ const Form = ({ className = '', layout, layoutDirection, initValues = [], submit
                                   placeholder={value.placeholder || ''} value={values[key]} onChange={handleChange}
                                   showError={!_.isEmpty(errors[key])} errorMessage={_.head(errors[key]) || ''}/>
             case 'select':
-                return <SelectField key={key} label={value.label} values={value.values || []} direction={dir}
+                return <SelectField key={key} label={value.label} values={value.values || []} value={getValue(key)} direction={dir}
                                     name={key} placeholder={value.placeholder || ''} onChange={handleChange}
                                     showError={!_.isEmpty(errors[key])} errorMessage={_.head(errors[key]) || ''}/>
             case 'checkbox':
@@ -77,9 +77,13 @@ const Form = ({ className = '', layout, layoutDirection, initValues = [], submit
 
 export default Form
 
+Form.defaultProps = {
+    initValues: {}
+}
+
 Form.propTypes = {
     className: PropTypes.string,
     layout: PropTypes.object.isRequired,
     layoutDirection: PropTypes.string,
-    initValues: PropTypes.array,
+    initValues: PropTypes.object,
 }

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -57,7 +57,7 @@ const Form = ({ className = '', layout, layoutDirection, initValues, submitButto
             case 'radio':
                 return <RadioButtonGroup key={index} label={value.label} direction={dir} inline={value.inline} items={value.values}
                                          name={key} showError={!_.isEmpty(errors[key])} onChange={handleChange}
-                                         errorMessage={_.head(errors[key]) || ''}/>
+                                         errorMessage={_.head(errors[key]) || ''} renderTabs={value.renderTabs}/>
             default:
                 throw new Error(`Unhandled form type: ${value.type}`)
         }

--- a/src/components/FormItem.jsx
+++ b/src/components/FormItem.jsx
@@ -16,5 +16,8 @@ FormItem.propTypes = {
     label: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
     direction: PropTypes.oneOf(Object.values(direction)),
-    children: PropTypes.array,
+    children: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.node),
+        PropTypes.node
+    ])
 }

--- a/src/components/RadioButton.jsx
+++ b/src/components/RadioButton.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { uniqueId } from '../constants/helper'
 
-const RadioButton = ({label, value, group, onChange, isChecked}) => {
+const RadioButton = ({label, value, group, onChange, isChecked, renderTabs}) => {
     const [ id ] = useState(() => uniqueId(`${_.camelCase(label)}-`))
 
     const handleChange = (e) => {
@@ -13,7 +13,7 @@ const RadioButton = ({label, value, group, onChange, isChecked}) => {
     return (
         <div className='radio-wrapper'>
             <input type='radio' value={value} name={group} onChange={handleChange} id={id} checked={isChecked}
-                   className='form-item__radio'/>
+                   className={`form-item__radio ${renderTabs && 'form-item__radio--tabs'} `}/>
             <label htmlFor={id}>{label}</label>
         </div>
     )
@@ -25,5 +25,7 @@ RadioButton.propTypes = {
     label: PropTypes.string.isRequired,
     value: PropTypes.string.isRequired,
     group: PropTypes.string.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    isChecked: PropTypes.bool,
+    renderTabs: PropTypes.bool,
 }

--- a/src/components/RadioButtonGroup.jsx
+++ b/src/components/RadioButtonGroup.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
-import {direction, uniqueId} from '../constants/helper'
+import {direction as directions, uniqueId} from '../constants/helper'
 import RadioButton from './RadioButton'
+import FormItem from './FormItem'
 import _ from "lodash";
 
-const RadioButtonGroup = ({items, name, label, inline, errorMessage, showError, onChange}) => {
+const RadioButtonGroup = ({items, name, label, direction, inline, errorMessage, showError, onChange}) => {
     const [ id ] = useState(() => uniqueId(`${_.camelCase(label)}-`))
     const [ currentValue, setCurrentValue] = useState('')
 
@@ -18,9 +19,8 @@ const RadioButtonGroup = ({items, name, label, inline, errorMessage, showError, 
     }
 
     return (
-        <div className={`form-item`}>
-            {label !== '' && <label className={`form-item__label`} htmlFor={id}>{label}</label>}
-            <div className={`form-item__radiogroup${inline ? direction.row : direction.column}`}>
+        <FormItem label={label} id={id} direction={direction}>
+            <div className={`form-item__radiogroup${inline ? directions.row : directions.column}`}>
                 {
                     items.map(item => <RadioButton key={uniqueId(`${_.camelCase(item.label)}-`)} label={item.label}
                                                    value={item.value} group={name} onChange={handleChange}
@@ -28,7 +28,7 @@ const RadioButtonGroup = ({items, name, label, inline, errorMessage, showError, 
                 }
             </div>
             <span className={`error-label ${showError ? '' : 'hide'}`}>{errorMessage}</span>
-        </div>
+        </FormItem>
     )
 }
 
@@ -38,7 +38,8 @@ RadioButtonGroup.propTypes = {
     items: PropTypes.arrayOf(PropTypes.shape).isRequired,
     name: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
-    inline: PropTypes.bool.isRequired,
+    direction: PropTypes.oneOf(Object.values(directions)),
+    inline: PropTypes.bool,
     errorMessage: PropTypes.string,
     showError: PropTypes.bool.isRequired,
     onChange: PropTypes.func.isRequired

--- a/src/components/RadioButtonGroup.jsx
+++ b/src/components/RadioButtonGroup.jsx
@@ -20,7 +20,7 @@ const RadioButtonGroup = ({items, name, label, value, direction, inline, renderT
 
     return isVisible && (
         <FormItem label={label} id={id} direction={direction}>
-            <div className={`form-item__radiogroup${inline ? direction.row : direction.column}`}>
+            <div className={`form-item__radiogroup${inline ? directions.row : directions.column}`}>
                 {
                     items.map(item => <RadioButton key={uniqueId(`${_.camelCase(item.label)}-`)} label={item.label}
                                                    value={item.value} group={name} onChange={handleChange}

--- a/src/components/RadioButtonGroup.jsx
+++ b/src/components/RadioButtonGroup.jsx
@@ -5,7 +5,7 @@ import RadioButton from './RadioButton'
 import FormItem from './FormItem'
 import _ from "lodash";
 
-const RadioButtonGroup = ({items, name, label, direction, inline, errorMessage, showError, onChange}) => {
+const RadioButtonGroup = ({items, name, label, direction, inline, renderTabs, errorMessage, showError, onChange}) => {
     const [ id ] = useState(() => uniqueId(`${_.camelCase(label)}-`))
     const [ currentValue, setCurrentValue] = useState('')
 
@@ -24,7 +24,7 @@ const RadioButtonGroup = ({items, name, label, direction, inline, errorMessage, 
                 {
                     items.map(item => <RadioButton key={uniqueId(`${_.camelCase(item.label)}-`)} label={item.label}
                                                    value={item.value} group={name} onChange={handleChange}
-                                                   isChecked={item.value === currentValue}/>)
+                                                   isChecked={item.value === currentValue} renderTabs={renderTabs} />)
                 }
             </div>
             <span className={`error-label ${showError ? '' : 'hide'}`}>{errorMessage}</span>
@@ -40,6 +40,7 @@ RadioButtonGroup.propTypes = {
     label: PropTypes.string.isRequired,
     direction: PropTypes.oneOf(Object.values(directions)),
     inline: PropTypes.bool,
+    renderTabs: PropTypes.bool,
     errorMessage: PropTypes.string,
     showError: PropTypes.bool.isRequired,
     onChange: PropTypes.func.isRequired

--- a/src/components/RadioButtonGroup.jsx
+++ b/src/components/RadioButtonGroup.jsx
@@ -5,9 +5,9 @@ import RadioButton from './RadioButton'
 import FormItem from './FormItem'
 import _ from "lodash";
 
-const RadioButtonGroup = ({items, name, label, direction, inline, renderTabs, errorMessage, showError, onChange}) => {
+const RadioButtonGroup = ({items, name, label, value, direction, inline, renderTabs, errorMessage, showError, onChange}) => {
     const [ id ] = useState(() => uniqueId(`${_.camelCase(label)}-`))
-    const [ currentValue, setCurrentValue] = useState('')
+    const [ currentValue, setCurrentValue] = useState(value)
 
     useEffect(() => {
         onChange(name, currentValue)
@@ -34,10 +34,15 @@ const RadioButtonGroup = ({items, name, label, direction, inline, renderTabs, er
 
 export default RadioButtonGroup
 
+RadioButtonGroup.defaultProps = {
+    value: ''
+}
+
 RadioButtonGroup.propTypes = {
     items: PropTypes.arrayOf(PropTypes.shape).isRequired,
     name: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
+    value: PropTypes.string,
     direction: PropTypes.oneOf(Object.values(directions)),
     inline: PropTypes.bool,
     renderTabs: PropTypes.bool,

--- a/src/components/SelectField.jsx
+++ b/src/components/SelectField.jsx
@@ -8,7 +8,7 @@ const SelectField = ({label, name, placeholder, values, value, direction, disabl
     const [ currentValue, setCurrentValue ] = useState(value)
 
     useEffect(() => {
-        onChange(name, isChecked ? currentValue : null, { isVisible })
+        onChange(name, currentValue, { isVisible })
     }, [currentValue, isVisible])
 
     const placeholderStyling = () => `${currentValue === placeholder && 'form-item__select--placeholder'}`

--- a/src/components/SelectField.jsx
+++ b/src/components/SelectField.jsx
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types'
 import { uniqueId, direction } from '../constants/helper'
 import FormItem from './FormItem'
 
-const SelectField = ({label, name, placeholder, values, direction, disabled = false, errorMessage, showError, onChange}) => {
+const SelectField = ({label, name, placeholder, values, value, direction, disabled = false, errorMessage, showError, onChange}) => {
     const [ id ] = useState(() => uniqueId(`${_.camelCase(label)}-`))
-    const [ currentValue, setCurrentValue ] = useState(placeholder)
+    const [ currentValue, setCurrentValue ] = useState(value)
     const [ isChecked, setIsChecked ] = useState(false)
 
     useEffect(() => {
@@ -43,6 +43,7 @@ SelectField.propTypes = {
     name: PropTypes.string.isRequired,
     placeholder: PropTypes.string,
     values: PropTypes.arrayOf(PropTypes.shape).isRequired,
+    value: PropTypes.string,
     direction: PropTypes.oneOf(Object.values(direction)),
     disabled: PropTypes.bool,
     errorMessage: PropTypes.string,

--- a/src/components/SelectField.jsx
+++ b/src/components/SelectField.jsx
@@ -6,16 +6,14 @@ import FormItem from './FormItem'
 const SelectField = ({label, name, placeholder, values, value, direction, disabled = false, errorMessage, showError, onChange}) => {
     const [ id ] = useState(() => uniqueId(`${_.camelCase(label)}-`))
     const [ currentValue, setCurrentValue ] = useState(value)
-    const [ isChecked, setIsChecked ] = useState(false)
 
     useEffect(() => {
-        onChange(name, isChecked ? currentValue : null)
+        onChange(name, currentValue)
     }, [currentValue])
 
     const placeholderStyling = () => `${currentValue === placeholder && 'form-item__select--placeholder'}`
 
     const handleChange = (e => {
-        setIsChecked(true)
         setCurrentValue(e.target.value)
     })
 

--- a/src/components/TextArea.jsx
+++ b/src/components/TextArea.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { direction, uniqueId } from '../constants/helper'
+import FormItem from './FormItem'
 import _ from 'lodash'
 
 const TextArea = ({label, name, value = '', direction, placeholder, onChange, errorMessage, showError}) => {
@@ -14,18 +15,14 @@ const TextArea = ({label, name, value = '', direction, placeholder, onChange, er
     const handleChange = e => setCurrentValue(e.target.value)
 
      return (
-         <div className={`form-item form-item${direction}`}>
-
-             {label !== '' && <label className={`form-item__label`} htmlFor={id}>{label}</label>}
-
+        <FormItem label={label} id={id} direction={direction}>
              <div className="form-item__inner">
                 <textarea className={`form-item__textarea ${showError ? 'error' : ''}`} placeholder={placeholder}
                           onChange={handleChange} name={name} htmlFor={id} value={value}>
                 </textarea>
                  <span className={`error-label ${showError ? '' : 'hide'}`}>{errorMessage}</span>
              </div>
-
-         </div>
+         </FormItem>
      )
 }
 

--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -53,8 +53,9 @@ const useForm = (callback, validators) => {
 export default useForm
 
 const validate = (value, validators) => {
+    const rules = _.get(validators, 'rules', [])
 
-    let errors = validators.rules.map(rule => {
+    let errors = rules.map(rule => {
         switch (rule) {
             case validate.types.REQUIRED:
                 return !value && copy.nl.error_is_required


### PR DESCRIPTION
This branch contains fixes for RadioButtonGroup and other components.

fix: Label not working for RadioButtonGroup
refactor: Made RadioButtonGroup use FormItem as wrapper
fix: FormItem always expecting multiple react nodes as children, throws when only one child is givven
refactor: Made TextArea use FormItem as wrapper
feat: Made SelectField listen to initValues
fix: React warning do not use both value and defaultValue on DateField

Also added the capability for RadioButtonGroup to render as Tabs

## Example:

```js
const layout = {
    period: {
        type: 'radio',
        label: '',
        inline: true,
        values: [{label: 'Per week', value: 'weekly'}, {label: 'Per maand', value: 'monthly'}],
        validators: [
            'isRequired'
        ]
    },
    period_inline: {
        type: 'radio',
        label: '',
        inline: false,
        values: [{label: 'Per week', value: 'weekly'}, {label: 'Per maand', value: 'monthly'}],
        validators: [
            'isRequired'
        ]
    },
    period_tabs: {
        type: 'radio',
        label: '',
        renderTabs: true,
        inline: true,
        values: [{label: 'Per week', value: 'weekly'}, {label: 'Per maand', value: 'monthly'}],
        validators: [
            'isRequired'
        ]
    },
    period_tabs_inline: {
        type: 'radio',
        label: '',
        renderTabs: true,
        inline: false,
        values: [{label: 'Per week', value: 'weekly'}, {label: 'Per maand', value: 'monthly'}],
        validators: [
            'isRequired'
        ]
    },
}
```

Would render as;

![Screenshot 2020-02-13 at 16 44 53](https://user-images.githubusercontent.com/17108331/74451636-3a5a5380-4e80-11ea-944d-4673326fa9fc.png)
