### PR TITLE
Feature/ux fixes

### DIFF
--- a/src/assets/styles/styles.scss
+++ b/src/assets/styles/styles.scss
@@ -62,6 +62,38 @@ $graphite: #4A4A4A;
     position: relative;
   }
 
+  &__text-wrapper {
+    &--euro {
+      position: relative;
+
+      input {
+        padding-left: 1.75em;
+      }
+
+      &:before {
+        content: "€";
+        position: absolute;
+        top: 0.75em;
+        left: 0.75em;
+      }
+    }
+
+    &--percentage {
+      position: relative;
+
+      input {
+        padding-right: 1.75em;
+      }
+
+      &:after {
+        content: "%";
+        position: absolute;
+        top: 0.75em;
+        right: 0.75em;
+      }
+    }
+  }
+
   &__label {
     margin: 0 0 6px 0;
     display: block;

--- a/src/assets/styles/styles.scss
+++ b/src/assets/styles/styles.scss
@@ -201,7 +201,11 @@ $graphite: #4A4A4A;
   RADIO BUTTON
    */
   .radio-wrapper {
-    flex: 1;
+    margin-top: 13px;
+
+    &--space-between {
+      flex: 1
+    }
   }
 
   &__radio {

--- a/src/assets/styles/styles.scss
+++ b/src/assets/styles/styles.scss
@@ -264,6 +264,7 @@ $graphite: #4A4A4A;
         width: 20px;
         height: 20px;
         border: 1px solid $grey;
+        background-color: white;
       }
 
       &:after {

--- a/src/components/DateField.jsx
+++ b/src/components/DateField.jsx
@@ -55,12 +55,11 @@ const DateField = ({ id, name, placeholder, value, showError, onChange }) => {
 
     return (
         <>
-            <div className="form-item__input-wrapper">
+            <div className="form-item__input-wrapper" onClick={handleInputClick}>
                 <input
                     className={`form-item__input ${showError && 'error'}`}
                     autoComplete="off"
                     placeholder={placeholder}
-                    onClick={handleInputClick}
                     name={name}
                     htmlFor={id}
                     onChange={handleChange}

--- a/src/components/DateField.jsx
+++ b/src/components/DateField.jsx
@@ -29,12 +29,12 @@ const DateField = ({ id, name, placeholder, value, showError, onChange }) => {
         }
 
         if (isCalendarPresent) {
-            document.addEventListener('mousedown', handleClickOutside)
+            document.addEventListener('mouseup', handleClickOutside)
         } else {
-            document.removeEventListener('mousedown', handleClickOutside)
+            document.removeEventListener('mouseup', handleClickOutside)
         }
 
-        return () => document.removeEventListener('mousedown', handleClickOutside)
+        return () => document.removeEventListener('mouseup', handleClickOutside)
 
     }, [isCalendarPresent, currentValue])
 

--- a/src/components/RadioButton.jsx
+++ b/src/components/RadioButton.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { uniqueId } from '../constants/helper'
 
-const RadioButton = ({label, value, group, onChange, isChecked, renderTabs}) => {
+const RadioButton = ({label, value, group, onChange, isChecked, renderTabs, spaceBetween}) => {
     const [ id ] = useState(() => uniqueId(`${_.camelCase(label)}-`))
 
     const handleChange = (e) => {
@@ -10,9 +10,9 @@ const RadioButton = ({label, value, group, onChange, isChecked, renderTabs}) => 
     }
 
     return (
-        <div className='radio-wrapper'>
+        <div className={`radio-wrapper ${spaceBetween && 'radio-wrapper--space-between'}`}>
             <input type='radio' value={value} name={group} onChange={handleChange} id={id} checked={isChecked}
-                   className={`form-item__radio ${renderTabs && 'form-item__radio--tabs'} `}/>
+                   className={`form-item__radio ${renderTabs && 'form-item__radio--tabs'}`}/>
             <label htmlFor={id}>{label}</label>
         </div>
     )
@@ -27,4 +27,5 @@ RadioButton.propTypes = {
     onChange: PropTypes.func.isRequired,
     isChecked: PropTypes.bool,
     renderTabs: PropTypes.bool,
+    spaceBetween: PropTypes.bool,
 }

--- a/src/components/RadioButtonGroup.jsx
+++ b/src/components/RadioButtonGroup.jsx
@@ -4,7 +4,7 @@ import { direction as directions, uniqueId } from '../constants/helper'
 import RadioButton from './RadioButton'
 import _ from 'lodash';
 
-const RadioButtonGroup = ({ values, name, value, inline, renderTabs, showError, onChange }) => {
+const RadioButtonGroup = ({ values, name, value, inline, renderTabs, spaceBetween, showError, onChange }) => {
     const [currentValue, setCurrentValue] = useState(value)
 
     useEffect(() => {
@@ -26,6 +26,7 @@ const RadioButtonGroup = ({ values, name, value, inline, renderTabs, showError, 
                 onChange={handleChange}
                 isChecked={item.value === currentValue}
                 renderTabs={renderTabs}
+                spaceBetween={spaceBetween}
             />)}
         </div>
     )
@@ -44,6 +45,7 @@ RadioButtonGroup.propTypes = {
     direction: PropTypes.oneOf(Object.values(directions)),
     inline: PropTypes.bool,
     renderTabs: PropTypes.bool,
+    spaceBetween: PropTypes.bool,
     showError: PropTypes.bool,
     onChange: PropTypes.func.isRequired
 }

--- a/src/components/TextField.jsx
+++ b/src/components/TextField.jsx
@@ -11,13 +11,28 @@ const getInputMode = type => {
             return 'tel'
         case 'number':
             return 'numeric'
+        case 'percentage':
+            return 'numeric'
+        case 'euro':
+            return 'numeric'
         default:
             return 'text'
     }
 }
 
+const getInputWrapperClass = type => {
+    switch (type) {
+        case 'percentage':
+        case 'euro':
+            return `form-item__text-wrapper form-item__text-wrapper--${type}`
+        default:
+            return 'form-item__text-wrapper'
+    }
+}
+
 const TextField = ({ id, name, placeholder, value, type, showError, onChange }) => {
     const [currentValue, setCurrentValue] = useState(value)
+    const wrapperClass = getInputWrapperClass(type)
 
     useEffect(() => {
         onChange(name, currentValue)
@@ -27,15 +42,17 @@ const TextField = ({ id, name, placeholder, value, type, showError, onChange }) 
     const inputMode = getInputMode(type)
 
     return (
-        <input
-            className={`form-item__input ${showError ? 'error' : ''}`}
-            placeholder={placeholder}
-            type={type}
-            onChange={handleChange}
-            name={name} htmlFor={id}
-            value={currentValue}
-            inputMode={inputMode}
-        />
+        <div className={wrapperClass}>
+            <input
+                className={`form-item__input ${showError ? 'error' : ''}`}
+                placeholder={placeholder}
+                type={type}
+                onChange={handleChange}
+                name={name} htmlFor={id}
+                value={currentValue}
+                inputMode={inputMode}
+            />
+        </div>
     )
 }
 

--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -25,6 +25,8 @@ const useForm = (callback, layout, customComponents) => {
         'email': TextField,
         'phone': TextField,
         'number': TextField,
+        'percentage': TextField,
+        'euro': TextField,
         'select': SelectField,
         'checkbox': Checkbox,
         'textarea': TextArea,


### PR DESCRIPTION
- fix: DateField popover not appearing when clicking on date icon
- fix: DateField popover flickering when selecting input
- fix: RadioButton toggle icon background being transparent

- feat: Implemented "euro" and "percentage" types

### Example

```js
const form = {
   layout = {
      repayment: {
            type: 'euro',
            label: 'Repayment',
            validators: [ 'isNumber' ]
        },
        interest: {
            type: 'percentage',
            label: 'Interest',
            validators: [ 'isNumber' ]
        },
   },
    initValues: {
        repayment: '100',
        interest: '5'
    }
}
```

Would be rendered as

<img width="714" alt="Screenshot 2020-04-03 at 14 59 55" src="https://user-images.githubusercontent.com/17108331/78363487-226b9a00-75bc-11ea-8e6e-27e80c4b31cc.png">

------

- feat: Added `spaceBetween` prop to type RadioButton and RadioButtonGroup

### Example:

```js
const layout = {
    period: {
        type: 'radio',
        label: 'Period',
        inline: true,
        values: [{label: 'Weekly', value: 'weekly'}, {label: 'Monthly', value: 'monthly'}],
        validators: [
            'isRequired'
        ]
    },
    period_space: {
        type: 'radio',
        label: 'Period with space between',
        inline: true,
        spaceBetween: true,
        values: [{label: 'Weekly', value: 'weekly'}, {label: 'Monthly', value: 'monthly'}],
        validators: [
            'isRequired'
        ]
    },
    period_tabs: {
        type: 'radio',
        label: 'Period (tabs)',
        renderTabs: true,
        inline: true,
        values: [{label: 'Weekly', value: 'weekly'}, {label: 'Monthly', value: 'monthly'}],
        validators: [
            'isRequired'
        ]
    },
    period_tabs_space: {
        type: 'radio',
        label: 'Period (tabs) with space between',
        renderTabs: true,
        spaceBetween: true,
        inline: true,
        values: [{label: 'Weekly', value: 'weekly'}, {label: 'Monthly', value: 'monthly'}],
        validators: [
            'isRequired'
        ]
    },
}
```

Would be rendered as

<img width="1057" alt="Screenshot 2020-04-03 at 15 53 19" src="https://user-images.githubusercontent.com/17108331/78368128-6f06a380-75c3-11ea-96f3-3ab5ac222b3a.png">
