### PR TITLE
Feature / Auto format money

### DIFF
--- a/src/components/TextField.jsx
+++ b/src/components/TextField.jsx
@@ -30,6 +30,32 @@ const getInputWrapperClass = type => {
     }
 }
 
+const formatMonetaryString = value => parseFloat(value)
+    .toLocaleString('nl-NL', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+
+const getFormattedInput = (type, value) => {
+    switch (type) {
+        case 'euro':
+            // If the value equals 0 or '', do nothing
+            if (!value) {
+                return value
+            }
+
+            // Check if the value ends with .99 or ,99 (assume those are cents)
+            const match = /^([0-9\.,]+)[\.,]([0-9]{2})$/.exec(value)
+
+            if (match) {
+                // Remove dots and comma's, add the cents and return
+                return formatMonetaryString(`${_.replace(match[1], new RegExp('[\\.,]', 'g'), '')}.${match[2]}`)
+            }
+
+            // Return the value with all dots and comma's removed
+            return formatMonetaryString(_.replace(value, new RegExp('[\\.,]', 'g'), ''))
+        default:
+            return value
+    }
+}
+
 const TextField = ({ id, name, placeholder, value, type, showError, onChange }) => {
     const [currentValue, setCurrentValue] = useState(value)
     const wrapperClass = getInputWrapperClass(type)
@@ -51,6 +77,7 @@ const TextField = ({ id, name, placeholder, value, type, showError, onChange }) 
                 name={name} htmlFor={id}
                 value={currentValue}
                 inputMode={inputMode}
+                onBlur={() => setCurrentValue(getFormattedInput(type, currentValue))}
             />
         </div>
     )

--- a/src/components/TextField.jsx
+++ b/src/components/TextField.jsx
@@ -42,11 +42,11 @@ const getFormattedInput = (type, value) => {
             }
 
             // Check if the value ends with .99 or ,99 (assume those are cents)
-            const match = /^([0-9\.,]+)[\.,]([0-9]{2})$/.exec(value)
+            const match = /^([0-9\.,]+)?[\.,]([0-9]+)$/.exec(value)
 
             if (match) {
                 // Remove dots and comma's, add the cents and return
-                return formatMonetaryString(`${_.replace(match[1], new RegExp('[\\.,]', 'g'), '')}.${match[2]}`)
+                return formatMonetaryString(`${_.replace(match[1] || '0', new RegExp('[\\.,]', 'g'), '')}.${match[2].substring(0, 2)}`)
             }
 
             // Return the value with all dots and comma's removed


### PR DESCRIPTION
Some users carry a phone with a foreign locale (not "NL-nl"). When they select an input with `inputMode="decimal"`, their phones display a keyboard with a dot instead of a comma. This limits these users from entering monetary values with cents (e.g. "123,45").

This PR proposes an auto formatter triggered by an `onBlur` on the `<TextField>` component. When a `<TextField>` of type `'euro'` is blurred, this formatter automatically converts a dots to comma's and vice versa.

The formatter assumes that when a value ends with either `.99` or `,99`, these last two digits are cents and should be saved. All other dots and comma's are then removed, and the result is put through a `parseFloat(value).toLocaleString()` to format it to human readable text again.