### PR TITLE
Feature/PDEV-1152: Add "sublabel" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "structoform",
-    "version": "1.1.41",
+    "version": "1.2.0",
     "description": "React form components",
     "main": "dist/index.js",
     "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "structoform",
-    "version": "1.1.40",
+    "version": "1.1.41",
     "description": "React form components",
     "main": "dist/index.js",
     "files": [

--- a/src/assets/styles/styles.scss
+++ b/src/assets/styles/styles.scss
@@ -1,6 +1,7 @@
 $night: #131C4E;
 $red: #C20013;
 $teal: #4DCBC3;
+$brown: #C0926C;
 $light-grey: #E4E4E4;
 $grey: #9E9E9E;
 $graphite: #4A4A4A;
@@ -54,6 +55,11 @@ $graphite: #4A4A4A;
     }
   }
 
+  &__label-wrapper {
+    display: flex;
+    flex-direction: row;
+  }
+
   &__inner {
     width: 100%;
   }
@@ -101,6 +107,15 @@ $graphite: #4A4A4A;
     margin: 0 0 6px 0;
     display: block;
     font-size: 0.875rem;
+    flex: 1;
+  }
+
+  &__sublabel {
+    margin: 0 0 6px 0;
+    display: block;
+    font-size: 0.775rem;
+    font-weight: bold;
+    color: $brown;
   }
 
   /*

--- a/src/components/FormItem.jsx
+++ b/src/components/FormItem.jsx
@@ -6,8 +6,8 @@ import { direction } from '../constants/helper'
 const FormItem = ({label, subLabel, id, direction, children}) =>
     <div className={`form-item form-item${direction}`}>
         <div className="form-item__label-wrapper">
-            {!_.isNil(label) && <label className={`form-item__label`} htmlFor={id}>{label}</label>}
-            {!_.isNil(subLabel) && <span className={`form-item__sublabel`}>{subLabel}</span>}
+            {!!label && <label className={`form-item__label`} htmlFor={id}>{label}</label>}
+            {!!subLabel && <span className={`form-item__sublabel`}>{subLabel}</span>}
         </div>
 
         <div className="form-item__inner">

--- a/src/components/FormItem.jsx
+++ b/src/components/FormItem.jsx
@@ -19,7 +19,7 @@ export default FormItem
 
 FormItem.propTypes = {
     label: PropTypes.string,
-    isRequired: PropTypes.bool,
+    subLabel: PropTypes.string,
     id: PropTypes.string.isRequired,
     direction: PropTypes.oneOf(Object.values(direction)),
     children: PropTypes.oneOfType([

--- a/src/components/FormItem.jsx
+++ b/src/components/FormItem.jsx
@@ -3,9 +3,13 @@ import PropTypes from 'prop-types'
 import _ from 'lodash'
 import { direction } from '../constants/helper'
 
-const FormItem = ({label, id, direction, children}) =>
+const FormItem = ({label, subLabel, id, direction, children}) =>
     <div className={`form-item form-item${direction}`}>
-        {!_.isNil(label) && <label className={`form-item__label`} htmlFor={id}>{label}</label>}
+        <div className="form-item__label-wrapper">
+            {!_.isNil(label) && <label className={`form-item__label`} htmlFor={id}>{label}</label>}
+            {!_.isNil(subLabel) && <span className={`form-item__sublabel`}>{subLabel}</span>}
+        </div>
+
         <div className="form-item__inner">
             {children}
         </div>
@@ -15,6 +19,7 @@ export default FormItem
 
 FormItem.propTypes = {
     label: PropTypes.string,
+    isRequired: PropTypes.bool,
     id: PropTypes.string.isRequired,
     direction: PropTypes.oneOf(Object.values(direction)),
     children: PropTypes.oneOfType([

--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -101,7 +101,7 @@ const useForm = (callback, layout, customComponents, _values = {}) => {
 
         if (FormComponent) {
             return isVisible && (
-                <FormItem label={_.get(itemLayout, 'label')} id={id} direction={direction}>
+                <FormItem label={_.get(itemLayout, 'label')} subLabel={_.get(itemLayout, 'subLabel')} id={id} direction={direction}>
                     <FormComponent
                         {...itemLayout}
                         id={id}


### PR DESCRIPTION
Allows the form builder to render sublabels. Useful for "optional" labels, e.g.

![image](https://user-images.githubusercontent.com/17108331/166476128-b8f0833a-f0d0-4871-b2e0-f3b0779297fc.png)
